### PR TITLE
Update PC-NSF-HiFiGAN ID and download URL

### DIFF
--- a/data/softwares/p.json
+++ b/data/softwares/p.json
@@ -18,7 +18,7 @@
     ]
   },
   {
-    "id": "pc-nsf-hifigan",
+    "id": "pc_nsf_hifigan_44.1k_hop512_128bin_2025.02",
     "names": {
       "en": "DiffSinger Community Vocoder - PC-NSF-HiFiGAN"
     },
@@ -38,8 +38,8 @@
         "version": "2025.02",
         "mirrors": [
           {
-            "url": "https://github.com/openvpi/vocoders/releases/download/pc-nsf-hifigan-44.1k-hop512-128bin-2025.02/pc_nsf_hifigan_44.1k_hop512_128bin_2025.02.portable.oudep",
-            "hash": "sha256:f9f4c3d692b96295baa505efebd3ade5060677398b509fac3bd2d9ec5ef640b4"
+            "url": "https://github.com/openvpi/vocoders/releases/download/pc-nsf-hifigan-44.1k-hop512-128bin-2025.02/pc_nsf_hifigan_44.1k_hop512_128bin_2025.02.oudep",
+            "hash": "sha256:ba7d43142d41f6900c8264b5662ca7125a50feb8760bb8b9615c61a8f5e6902e"
           }
         ]
       }


### PR DESCRIPTION
To keep compatibility with old voicebanks and the previous oudep before package index was created, we have to include the full name as package ID.